### PR TITLE
영상 리스트 조회

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -11,5 +11,6 @@
         <module name="meerkatai.meerkatai.main" />
       </profile>
     </annotationProcessing>
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -8,7 +8,7 @@
         <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.36/5a30490a6e14977d97d9c73c924c1f1b5311ea95/lombok-1.18.36.jar" />
         </processorPath>
-        <module name="meerkatai.meerkatai.main" />
+        <module name="meerkatai.meerkatai.main~1" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="17" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/meerkatai.meerkatai.main.iml" filepath="$PROJECT_DIR$/.idea/modules/meerkatai.meerkatai.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/meerkatai.meerkatai.main~1.iml" filepath="$PROJECT_DIR$/.idea/modules/meerkatai.meerkatai.main~1.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/meerkatai.iml" filepath="$PROJECT_DIR$/.idea/meerkatai.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/meerkatai.meerkatai.main.iml" filepath="$PROJECT_DIR$/.idea/modules/meerkatai.meerkatai.main.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/modules/meerkatai.meerkatai.main.iml
+++ b/.idea/modules/meerkatai.meerkatai.main.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="AdditionalModuleElements">
-    <content url="file://$MODULE_DIR$/../../meerkatai/build/generated/sources/annotationProcessor/java/main">
-      <sourceFolder url="file://$MODULE_DIR$/../../meerkatai/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
-    </content>
-  </component>
-</module>

--- a/.idea/modules/meerkatai.meerkatai.main.iml
+++ b/.idea/modules/meerkatai.meerkatai.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../meerkatai/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../meerkatai/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/meerkatai/build.gradle
+++ b/meerkatai/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/meerkatai/src/main/java/com/capstone/meerkatai/config/SecurityConfig.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/config/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.capstone.meerkatai.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // ✅ 최신 문법
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/videos/list/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}

--- a/meerkatai/src/main/java/com/capstone/meerkatai/config/SecurityConfig.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/config/SecurityConfig.java
@@ -15,7 +15,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable()) // ✅ 최신 문법
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/videos/list/**").permitAll()
+                        .requestMatchers("/api/v1/**").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/meerkatai/src/main/java/com/capstone/meerkatai/video/controller/VideoController.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/video/controller/VideoController.java
@@ -1,47 +1,74 @@
 package com.capstone.meerkatai.video.controller;
 
+import com.capstone.meerkatai.video.dto.GetVideoListResponse;
 import com.capstone.meerkatai.video.entity.Video;
 import com.capstone.meerkatai.video.service.VideoService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/api/videos")
+@RequestMapping("/api/v1/videos")
 @RequiredArgsConstructor
 public class VideoController {
 
     private final VideoService videoService;
 
-    @GetMapping
-    public List<Video> getAll() {
-        return videoService.findAll();
+    //JWT 작성 전 임시 코드
+    // 예시: /api/v1/video/list/3?page=1
+    @GetMapping("/list/{userId}")
+    public ResponseEntity<GetVideoListResponse> getVideosByUser(
+            @PathVariable("userId") Integer userId,
+            @RequestParam(value = "page", defaultValue = "1") int page
+    ) {
+        GetVideoListResponse response = videoService.getVideosByUser(userId, page);
+        return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/{id}")
-    public Optional<Video> getById(@PathVariable Integer id) {
-        return videoService.findById(id);
-    }
+    // JWT 코드 작성 후 이걸로 하면 될듯.
+//    @GetMapping("/list")
+//    public ResponseEntity<GetVideoListResponse> getVideosByUser(
+//            @RequestHeader("Authorization") String authHeader,
+//            @RequestParam(value = "page", defaultValue = "1") int page
+//    ) {
+//        String token = authHeader.replace("Bearer ", "");
+//        Integer userId = jwtUtil.getUserIdFromToken(token).intValue(); // userId가 Long이면 int로 변환
+//
+//        GetVideoListResponse response = videoService.getVideosByUser(userId, page);
+//        return ResponseEntity.ok(response);
+//    }
 
-    @GetMapping("/user/{userId}")
-    public List<Video> getByUserId(@PathVariable Integer userId) {
-        return videoService.findByUserId(userId);
-    }
 
-    @GetMapping("/streaming/{streamingVideoId}")
-    public List<Video> getByStreamingVideoId(@PathVariable Integer streamingVideoId) {
-        return videoService.findByStreamingVideoId(streamingVideoId);
-    }
-
-    @PostMapping
-    public Video create(@RequestBody Video video) {
-        return videoService.save(video);
-    }
-
-    @DeleteMapping("/{id}")
-    public void delete(@PathVariable Integer id) {
-        videoService.delete(id);
-    }
+//    @GetMapping
+//    public List<Video> getAll() {
+//        return videoService.findAll();
+//    }
+//
+//    @GetMapping("/{id}")
+//    public Optional<Video> getById(@PathVariable Integer id) {
+//        return videoService.findById(id);
+//    }
+//
+//    @GetMapping("/user/{userId}")
+//    public List<Video> getByUserId(@PathVariable Integer userId) {
+//        return videoService.findByUserId(userId);
+//    }
+//
+//    @GetMapping("/streaming/{streamingVideoId}")
+//    public List<Video> getByStreamingVideoId(@PathVariable Integer streamingVideoId) {
+//        return videoService.findByStreamingVideoId(streamingVideoId);
+//    }
+//
+//    @PostMapping
+//    public Video create(@RequestBody Video video) {
+//        return videoService.save(video);
+//    }
+//
+//    @DeleteMapping("/{id}")
+//    public void delete(@PathVariable Integer id) {
+//        videoService.delete(id);
+//    }
 }

--- a/meerkatai/src/main/java/com/capstone/meerkatai/video/dto/GetVideoListResponse.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/video/dto/GetVideoListResponse.java
@@ -1,0 +1,48 @@
+package com.capstone.meerkatai.video.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetVideoListResponse {
+    private String status;
+    private Data data;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Data {
+        private List<VideoDto> videos;
+        private Pagination pagination;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class VideoDto {
+        private Long video_id;
+        private String file_path;
+        private String thumbnail_path;
+        private int duration;
+        private long file_size;
+        private boolean video_status;
+        private String created_at;
+        private Long streaming_video_id;
+        private String anomaly_behavior_type;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Pagination {
+        private int total;
+        private int page;
+        private int pages;
+        private int limit;
+    }
+}

--- a/meerkatai/src/main/java/com/capstone/meerkatai/video/dto/VideoDownloadRequest.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/video/dto/VideoDownloadRequest.java
@@ -1,0 +1,10 @@
+package com.capstone.meerkatai.video.dto;
+
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public class VideoDownloadRequest {
+    private Integer userId;
+    private List<Integer> videoIds;
+}

--- a/meerkatai/src/main/java/com/capstone/meerkatai/video/entity/Video.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/video/entity/Video.java
@@ -1,14 +1,17 @@
 package com.capstone.meerkatai.video.entity;
 
-import com.capstone.meerkatai.anomalybehavior.entity.AnomalyBehaviorType;
+import com.capstone.meerkatai.anomalybehavior.entity.AnomalyBehavior;
 import com.capstone.meerkatai.streamingvideo.entity.StreamingVideo;
 import com.capstone.meerkatai.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Getter @Setter @NoArgsConstructor
+@Getter
+@Setter
+@NoArgsConstructor
 public class Video {
+
     @Id
     private Integer videoId;
 
@@ -31,11 +34,11 @@ public class Video {
     @JoinColumn(name = "streaming_video_id", nullable = false)
     private StreamingVideo streamingVideo;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private AnomalyBehaviorType anomalyBehaviorType;
-
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @OneToOne
+    @JoinColumn(name = "anomaly_id", nullable = false, unique = true)
+    private AnomalyBehavior anomalyBehavior;
 }

--- a/meerkatai/src/main/java/com/capstone/meerkatai/video/repository/VideoRepository.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/video/repository/VideoRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface VideoRepository extends JpaRepository<Video, Integer> {
     List<Video> findByUserUserId(Integer userId);
     List<Video> findByStreamingVideoStreamingVideoId(Integer streamingVideoId);
+    List<Video> findByUser_UserIdAndVideoIdIn(Integer userId, List<Integer> videoIds);
 }

--- a/meerkatai/src/main/java/com/capstone/meerkatai/video/service/VideoService.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/video/service/VideoService.java
@@ -4,8 +4,14 @@ import com.capstone.meerkatai.video.dto.GetVideoListResponse;
 import com.capstone.meerkatai.video.entity.Video;
 import com.capstone.meerkatai.video.repository.VideoRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.Optional;
@@ -52,6 +58,38 @@ public class VideoService {
 
         return new GetVideoListResponse("success", data);
     }
+
+
+
+
+
+    public List<Pair<String, InputStream>> getVideoStreams(Integer userId, List<Integer> videoIds) {
+        List<Video> videos = videoRepository.findByUser_UserIdAndVideoIdIn(userId, videoIds);
+
+        List<Pair<String, InputStream>> result = new ArrayList<>();
+
+        for (Video video : videos) {
+            try {
+                String path = video.getFilePath();
+                InputStream stream;
+
+                if (path.startsWith("http")) {
+                    URL url = new URL(path);
+                    stream = url.openStream();
+                } else {
+                    File file = new File(path);
+                    if (!file.exists()) continue;
+                    stream = new FileInputStream(file);
+                }
+
+                result.add(Pair.of("video_" + video.getVideoId() + ".mp4", stream));
+            } catch (Exception ignored) {}
+        }
+
+        return result;
+    }
+
+
 
 //    public List<Video> findAll() {
 //        return videoRepository.findAll();

--- a/meerkatai/src/main/java/com/capstone/meerkatai/video/service/VideoService.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/video/service/VideoService.java
@@ -1,11 +1,13 @@
 package com.capstone.meerkatai.video.service;
 
+import com.capstone.meerkatai.video.dto.GetVideoListResponse;
 import com.capstone.meerkatai.video.entity.Video;
 import com.capstone.meerkatai.video.repository.VideoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.Optional;
 
 @Service
@@ -14,27 +16,64 @@ public class VideoService {
 
     private final VideoRepository videoRepository;
 
-    public List<Video> findAll() {
-        return videoRepository.findAll();
+    public GetVideoListResponse getVideosByUser(Integer userId, int page) {
+        final int limit = 6;
+        int offset = (page - 1) * limit;
+
+        // 전체 영상 리스트 가져오기 (페이징 없는 상태)
+        List<Video> allVideos = videoRepository.findByUserUserId(userId);
+        int total = allVideos.size();
+        int pages = (int) Math.ceil((double) total / limit);
+
+        // Java로 페이징 처리
+        List<Video> pagedVideos = allVideos.stream()
+                .skip(offset)
+                .limit(limit)
+                .toList();
+
+        // 엔티티 → DTO 변환
+        List<GetVideoListResponse.VideoDto> videoDtoList = pagedVideos.stream()
+                .map(video -> new GetVideoListResponse.VideoDto(
+                        video.getVideoId().longValue(),
+                        video.getFilePath(),
+                        video.getThumbnailPath(),
+                        video.getDuration(),
+                        video.getFileSize(),
+                        video.getVideoStatus(),
+                        video.getAnomalyBehavior().getAnomalyTime().toString(), // 수정된 부분
+                        video.getStreamingVideo().getStreamingVideoId().longValue(),
+                        video.getAnomalyBehavior().getAnomalyBehaviorType().name() // 이 부분도 anomalyBehavior를 통해 접근해야 함
+                ))
+                .collect(Collectors.toList());
+
+        // pagination 구성
+        GetVideoListResponse.Pagination pagination = new GetVideoListResponse.Pagination(total, page, pages, limit);
+        GetVideoListResponse.Data data = new GetVideoListResponse.Data(videoDtoList, pagination);
+
+        return new GetVideoListResponse("success", data);
     }
 
-    public Optional<Video> findById(Integer id) {
-        return videoRepository.findById(id);
-    }
-
-    public List<Video> findByUserId(Integer userId) {
-        return videoRepository.findByUserUserId(userId);
-    }
-
-    public List<Video> findByStreamingVideoId(Integer streamingVideoId) {
-        return videoRepository.findByStreamingVideoStreamingVideoId(streamingVideoId);
-    }
-
-    public Video save(Video video) {
-        return videoRepository.save(video);
-    }
-
-    public void delete(Integer id) {
-        videoRepository.deleteById(id);
-    }
+//    public List<Video> findAll() {
+//        return videoRepository.findAll();
+//    }
+//
+//    public Optional<Video> findById(Integer id) {
+//        return videoRepository.findById(id);
+//    }
+//
+//    public List<Video> findByUserId(Integer userId) {
+//        return videoRepository.findByUserUserId(userId);
+//    }
+//
+//    public List<Video> findByStreamingVideoId(Integer streamingVideoId) {
+//        return videoRepository.findByStreamingVideoStreamingVideoId(streamingVideoId);
+//    }
+//
+//    public Video save(Video video) {
+//        return videoRepository.save(video);
+//    }
+//
+//    public void delete(Integer id) {
+//        videoRepository.deleteById(id);
+//    }
 }


### PR DESCRIPTION
## 기능 추가:
1. 영상 리스트 조회
2. 영상 다운로드

## 변경 사항:
1. 
![image](https://github.com/user-attachments/assets/17c7a255-6d6f-443b-8b0a-6f756c3ed63b)
Response에 
anomaly_count 없앰.
anomalyType 추가함.
cctv_name은  추가 논의 필요함. ->
1). 홈페이지에 영상 리스트가 있으면 현재 활성화 되어있는 모든 cctv의 영상 리스트가 섞여 있는건지 
2). 그것이 아니라면 cctv 설정 필터 같은 것이 필요해 보임.

2.
![image](https://github.com/user-attachments/assets/e56f2c2c-337d-4ee7-ae35-375e137f9f3f)
영상 다운로드에 video_id를 여러 개를 받을 수 있어야 해서 post로 바꿈

## 버그 수정:

## 개선 사항:

## 테스트 사항:
1. 임의로 mysql에 데이터 삽입하고 postman을 통해 테스트 완료
![image](https://github.com/user-attachments/assets/0624939c-0db2-494c-a090-c466be5711bc)

2. 임의의 인터넷 무료 영상 다운로드 링크 mysql video엔티티의 file_path에 저장하고 다운로드 테스트 완료
![image](https://github.com/user-attachments/assets/5d240c8b-9cd6-48a5-909f-4ac118fe8a6b)


## 참고 사항:
#현재 로그인 파트와 코드 연동이 안되어 JWT 인증이 안된 상태임.
그래서 JWT토큰으로 authHeader를 설정하는 방식 대신 api에 userId를 pathVariable로 입력하는 방식을 선택하여 임시로 코드를 작성 해둔 상태임. 
추후 JWT 연동 가능한 버전의 코드 또한 작성하여 주석 처리 해둠.

#또한 임의로 pathVariable을 이용해서 userId를 입력해 테스트 하려 했는데, spring-security 제약에 의해 테스트가 안되었음. 
그래서 config 패키지를 임시로 만들고 거기에 SecurityConfig 클래스를 임시로 만들어서 이 api에 대한 제약조건을 작성해서 테스트 완료함.