### PR TITLE
Fix: 특정 사용자 상세 정보 조회 API를 /api/v1/auth/me로 변경

### DIFF
--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/controller/AuthController.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/controller/AuthController.java
@@ -2,9 +2,13 @@ package com.capstone.meerkatai.user.controller;
 
 import com.capstone.meerkatai.user.dto.*;
 import com.capstone.meerkatai.user.service.AuthService;
+import com.capstone.meerkatai.user.entity.User;
+import com.capstone.meerkatai.user.repository.UserRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -16,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
   private final AuthService authService;
+  private final UserRepository userRepository;
 
   /**
    * 새로운 사용자를 등록
@@ -70,11 +75,24 @@ public class AuthController {
     return ResponseEntity.ok(new ApiResponse<>("success", "비밀번호가 성공적으로 변경되었습니다."));
   }
 
-  //특정 사용자의 상세 정보를 조회
+  /**
+   * 현재 인증된 사용자의 상세 정보를 조회합니다.
+   * JWT 토큰에서 추출한 사용자 이메일을 사용하여 해당 사용자 정보를 반환합니다.
+   *
+   * @return 현재 인증된 사용자의 정보가 포함된 ApiResponse 객체
+   */
+  @GetMapping("/me")
+  public ResponseEntity<ApiResponse<UserInfoResponse>> getCurrentUserInfo() {
+    // 현재 인증된 사용자 정보 가져오기
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    String email = authentication.getName(); // JWT에서 추출한 사용자 이메일
 
-  @GetMapping("/info/{id}")
-  public ResponseEntity<ApiResponse<UserInfoResponse>> getUserInfo(@PathVariable Long id) {
-    UserInfoResponse response = authService.getUserInfo(id);
+    // 이메일로 사용자 조회
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+    // 사용자 정보 조회
+    UserInfoResponse response = authService.getUserInfo(user.getUserId());
     return ResponseEntity.ok(new ApiResponse<>("success", response));
   }
 


### PR DESCRIPTION
## 기능 수정:
Fix: 특정 사용자 상세 정보 조회 API를 /api/v1/auth/me로 변경

## 변경 사항:

## 버그 수정:

## 개선 사항:

## 테스트 사항:
- postman으로 테스트 완료

<img width="877" alt="image" src="https://github.com/user-attachments/assets/4cddd54e-4e8f-4f94-b75c-28371a999ae6" />

## 참고 사항:

