### PR TITLE
Feat: 비밀번호 초기화시 기존비밀번호 검증, 예외처리

### DIFF
--- a/meerkatai/src/main/java/com/capstone/meerkatai/common/exception/GlobalExceptionHandler.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/common/exception/GlobalExceptionHandler.java
@@ -3,7 +3,12 @@ package com.capstone.meerkatai.common.exception;
 import com.capstone.meerkatai.common.dto.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,12 +27,103 @@ public class GlobalExceptionHandler {
   private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
   /**
+   * 유효성 검사(@Valid) 실패 시 발생하는 예외를 처리합니다.
+   * 각 필드별 오류 메시지를 추출하여 깔끔한 응답을 반환합니다.
+   *
+   * @param ex 처리할 MethodArgumentNotValidException 객체
+   * @return HTTP 400(Bad Request) 상태 코드와 유효성 검사 오류 메시지가 포함된 API 응답
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ResponseEntity<ApiResponse<Void>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+    // 첫 번째 오류 메시지만 추출
+    FieldError fieldError = ex.getBindingResult().getFieldError();
+    String errorMessage = fieldError != null ? fieldError.getDefaultMessage() : "유효성 검사에 실패했습니다";
+    
+    // 디버그 로그에 상세 정보 기록
+    log.debug("유효성 검사 실패: 필드={}, 값={}, 메시지={}",
+        fieldError != null ? fieldError.getField() : "unknown",
+        fieldError != null ? fieldError.getRejectedValue() : "unknown",
+        errorMessage);
+    
+    ApiResponse<Void> response = ApiResponse.error(errorMessage);
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  /**
+   * IllegalArgumentException 예외를 처리합니다.
+   * 주로 비즈니스 로직에서 잘못된 인자가 전달될 때 발생합니다.
+   *
+   * @param ex 처리할 IllegalArgumentException 객체
+   * @return HTTP 400(Bad Request) 상태 코드와 오류 메시지가 포함된 API 응답
+   */
+  @ExceptionHandler(IllegalArgumentException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(IllegalArgumentException ex) {
+    log.debug("잘못된 인자: {}", ex.getMessage());
+    ApiResponse<Void> response = ApiResponse.error(ex.getMessage());
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+  
+  /**
+   * 인증 실패 예외를 처리합니다.
+   *
+   * @param ex 처리할 BadCredentialsException 객체
+   * @return HTTP 401(Unauthorized) 상태 코드와 오류 메시지가 포함된 API 응답
+   */
+  @ExceptionHandler(BadCredentialsException.class)
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  public ResponseEntity<ApiResponse<Void>> handleBadCredentialsException(BadCredentialsException ex) {
+    log.debug("인증 실패: {}", ex.getMessage());
+    ApiResponse<Void> response = ApiResponse.error(ex.getMessage());
+    return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+  }
+  
+  /**
+   * Spring Security의 모든 인증 관련 예외를 처리합니다.
+   *
+   * @param ex 처리할 AuthenticationException 객체
+   * @return HTTP 401(Unauthorized) 상태 코드와 오류 메시지가 포함된 API 응답
+   */
+  @ExceptionHandler(AuthenticationException.class)
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  public ResponseEntity<ApiResponse<Void>> handleAuthenticationException(AuthenticationException ex) {
+    log.debug("인증 오류: {}", ex.getMessage());
+    ApiResponse<Void> response = ApiResponse.error("인증에 실패했습니다: " + ex.getMessage());
+    return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+  }
+  
+  /**
+   * 인증 관련 RuntimeException을 처리합니다.
+   * 로그인 과정에서 발생하는 예외를 처리합니다.
+   *
+   * @param ex 처리할 RuntimeException 객체
+   * @return HTTP 400(Bad Request) 상태 코드와 오류 메시지가 포함된 API 응답
+   */
+  @ExceptionHandler(RuntimeException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ResponseEntity<ApiResponse<Void>> handleRuntimeException(RuntimeException ex) {
+    // 로그인 처리 중 오류인지 확인
+    if (ex.getMessage() != null && ex.getMessage().startsWith("로그인 처리 중 오류")) {
+      log.error("로그인 처리 오류: {}", ex.getMessage());
+      ApiResponse<Void> response = ApiResponse.error("로그인 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+      return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+    
+    // 그 외 RuntimeException은 일반 서버 오류로 처리
+    log.error("런타임 오류: ", ex);
+    ApiResponse<Void> response = ApiResponse.error("요청을 처리하는 중 오류가 발생했습니다.");
+    return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  /**
    * 리소스를 찾을 수 없을 때 발생하는 ResourceNotFoundException을 처리합니다.
    *
    * @param ex 처리할 ResourceNotFoundException 객체
    * @return HTTP 404(Not Found) 상태 코드와 오류 메시지가 포함된 API 응답
    */
   @ExceptionHandler(ResourceNotFoundException.class)
+  @ResponseStatus(HttpStatus.NOT_FOUND)
   public ResponseEntity<ApiResponse<Void>> handleResourceNotFoundException(ResourceNotFoundException ex) {
     log.error("Resource not found: {}", ex.getMessage());
     ApiResponse<Void> response = ApiResponse.error(ex.getMessage());
@@ -41,6 +137,7 @@ public class GlobalExceptionHandler {
    * @return HTTP 400(Bad Request) 상태 코드와 오류 메시지가 포함된 API 응답
    */
   @ExceptionHandler(BusinessException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
   public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException ex) {
     log.error("Business exception: {}", ex.getMessage());
     ApiResponse<Void> response = ApiResponse.error(ex.getMessage());
@@ -55,9 +152,10 @@ public class GlobalExceptionHandler {
    * @return HTTP 500(Internal Server Error) 상태 코드와 일반적인 오류 메시지가 포함된 API 응답
    */
   @ExceptionHandler(Exception.class)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   public ResponseEntity<ApiResponse<Void>> handleGenericException(Exception ex) {
     log.error("Unexpected error: ", ex);
-    ApiResponse<Void> response = ApiResponse.error("서버 오류가 발생했습니다.");
+    ApiResponse<Void> response = ApiResponse.error("서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
     return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/controller/AuthController.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/controller/AuthController.java
@@ -121,8 +121,7 @@ public class AuthController {
    * {
    *   "user_id": 123,
    *   "user_name": "김철수",
-   *   "user_password": "newpassword123",
-   *   "notify_status": false
+   *   "user_password": "newpassword123"
    * }
    * </pre>
    */

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/controller/AuthController.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/controller/AuthController.java
@@ -147,11 +147,4 @@ public class AuthController {
     authService.withdraw(request);
     return ResponseEntity.ok(new ApiResponse<>("success", "회원 탈퇴가 완료되었습니다."));
   }
-
-  //컨트롤러에서 발생하는 예외를 처리
-
-  @ExceptionHandler(Exception.class)
-  public ResponseEntity<ApiResponse<String>> handleException(Exception e) {
-    return ResponseEntity.badRequest().body(new ApiResponse<>("error", e.getMessage()));
-  }
 }

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/controller/AuthController.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/controller/AuthController.java
@@ -65,6 +65,7 @@ public class AuthController {
    * <pre>
    * {
    *   "user_email": "user@example.com",
+   *   "user_password": "currentpassword123",
    *   "new_password": "newpassword123"
    * }
    * </pre>

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/LogoutRequest.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/LogoutRequest.java
@@ -19,7 +19,7 @@ public class LogoutRequest {
    * 이 ID를 통해 로그아웃 처리할 사용자를 식별합니다.
    * </p>
    */
-  @NotNull
+  @NotNull(message = "사용자 ID는 필수 입력 항목입니다")
   @JsonProperty("user_id")
   private Long userId;
 }

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/ResetPasswordRequest.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/ResetPasswordRequest.java
@@ -25,6 +25,17 @@ public class ResetPasswordRequest {
   private String userEmail;
 
   /**
+   * 현재 비밀번호
+   * <p>
+   * 빈 값이 허용되지 않는 필수 입력 항목
+   * 비밀번호 변경 전 본인 확인을 위해 사용
+   * </p>
+   */
+  @NotBlank
+  @JsonProperty("user_password")
+  private String userPassword;
+
+  /**
    * 새로 설정할 비밀번호
    * <p>
    * 빈 값이 허용되지 않는 필수 입력 항목

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/ResetPasswordRequest.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/ResetPasswordRequest.java
@@ -19,8 +19,8 @@ public class ResetPasswordRequest {
    * 이 이메일을 통해 사용자를 식별
    * </p>
    */
-  @NotBlank
-  @Email
+  @NotBlank(message = "이메일은 필수 입력 항목입니다")
+  @Email(message = "올바른 형식의 이메일 주소여야 합니다")
   @JsonProperty("user_email")
   private String userEmail;
 
@@ -31,7 +31,7 @@ public class ResetPasswordRequest {
    * 비밀번호 변경 전 본인 확인을 위해 사용
    * </p>
    */
-  @NotBlank
+  @NotBlank(message = "현재 비밀번호는 필수 입력 항목입니다")
   @JsonProperty("user_password")
   private String userPassword;
 
@@ -42,7 +42,7 @@ public class ResetPasswordRequest {
    * 서비스에서 암호화되어 저장
    * </p>
    */
-  @NotBlank
+  @NotBlank(message = "새 비밀번호는 필수 입력 항목입니다")
   @JsonProperty("new_password")
   private String newPassword;
 }

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/SignInRequest.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/SignInRequest.java
@@ -13,12 +13,12 @@ import lombok.Setter;
 @Setter
 public class SignInRequest {
 
-  @NotBlank
-  @Email
+  @NotBlank(message = "이메일은 필수 입력 항목입니다")
+  @Email(message = "올바른 형식의 이메일 주소여야 합니다")
   @JsonProperty("user_email")
   private String userEmail;
 
-  @NotBlank
+  @NotBlank(message = "비밀번호는 필수 입력 항목입니다")
   @JsonProperty("user_password")
   private String userPassword;
 }

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/SignInResponse.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/SignInResponse.java
@@ -35,6 +35,13 @@ public class SignInResponse {
   private String userName;
 
   /**
+   * 사용자의 알림 설정 상태입니다.
+   * true: 알림 활성화, false: 알림 비활성화
+   */
+  @JsonProperty("notify_status")
+  private Boolean notifyStatus;
+
+  /**
    * 사용자의 최초 로그인 여부입니다.
    * true인 경우 사용자가 처음으로 로그인한 것을 의미합니다.
    */
@@ -61,6 +68,7 @@ public class SignInResponse {
    *   "expiresIn": 86400,
    *   "user_id": 123,
    *   "user_name": "홍길동",
+   *   "notify_status": true,
    *   "first_login": false,
    *   "total_space": 1073741824,
    *   "used_space": 52428800

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/SignUpRequest.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/SignUpRequest.java
@@ -22,21 +22,20 @@ import lombok.Setter;
 @AllArgsConstructor
 public class SignUpRequest {
 
-  @NotBlank
-  @Email
+  @NotBlank(message = "이메일은 필수 입력 항목입니다")
+  @Email(message = "올바른 형식의 이메일 주소여야 합니다")
   @JsonProperty("user_email")
   private String userEmail;
 
-  @NotBlank
+  @NotBlank(message = "비밀번호는 필수 입력 항목입니다")
   @JsonProperty("user_password")
   private String userPassword;
 
-
-  @NotBlank
+  @NotBlank(message = "이름은 필수 입력 항목입니다")
   @JsonProperty("user_name")
   private String userName;
 
-  @NotNull
+  @NotNull(message = "약관 동의 여부는 필수 입력 항목입니다")
   @JsonProperty("agreement_status")
   private Boolean agreementStatus;
 

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/UpdateUserRequest.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/UpdateUserRequest.java
@@ -18,7 +18,7 @@ public class UpdateUserRequest {
    * 이 ID를 통해 업데이트할 사용자를 식별합니다.
    * </p>
    */
-  @NotNull
+  @NotNull(message = "사용자 ID는 필수 입력 항목입니다")
   @JsonProperty("user_id")
   private Long userId;
 

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/UpdateUserRequest.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/UpdateUserRequest.java
@@ -42,15 +42,4 @@ public class UpdateUserRequest {
    */
   @JsonProperty("user_password")
   private String userPassword;
-
-  /**
-   * 변경할 사용자의 알림 설정 상태입니다.
-   * <p>
-   * 선택적 입력 항목입니다.
-   * null인 경우 알림 설정이 변경되지 않습니다.
-   * true: 알림 활성화, false: 알림 비활성화
-   * </p>
-   */
-  @JsonProperty("notify_status")
-  private Boolean notifyStatus;
 }

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/UpdateUserResponse.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/UpdateUserResponse.java
@@ -24,13 +24,6 @@ public class UpdateUserResponse {
   private String userName;
 
   /**
-   * 수정된 사용자의 알림 설정 상태입니다.
-   * true: 알림 활성화, false: 알림 비활성화
-   */
-  @JsonProperty("notify_status")
-  private Boolean notifyStatus;
-
-  /**
    * 사용자 정보가 업데이트된 시간입니다.
    * ISO 8601 형식의 타임스탬프로 반환됩니다.
    */

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/WithdrawRequest.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/dto/WithdrawRequest.java
@@ -19,7 +19,7 @@ public class WithdrawRequest {
    * 이 ID를 통해 탈퇴 처리할 사용자를 식별합니다.
    * </p>
    */
-  @NotNull
+  @NotNull(message = "사용자 ID는 필수 입력 항목입니다")
   @JsonProperty("user_id")
   private Long userId;
 
@@ -30,7 +30,7 @@ public class WithdrawRequest {
    * 본인 확인을 위해 비밀번호를 검증합니다.
    * </p>
    */
-  @NotBlank
+  @NotBlank(message = "비밀번호는 필수 입력 항목입니다")
   @JsonProperty("user_password")
   private String userPassword;
 }

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/service/AuthServiceImpl.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/service/AuthServiceImpl.java
@@ -126,6 +126,7 @@ public class AuthServiceImpl implements AuthService {
           .expiresIn(86400)
           .userId(user.getUserId())
           .userName(user.getName())
+          .notifyStatus(user.isNotification())
           .firstLogin(isFirstLogin)
           .totalSpace(totalSpace)
           .usedSpace(usedSpace)

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/service/AuthServiceImpl.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/service/AuthServiceImpl.java
@@ -208,14 +208,10 @@ public class AuthServiceImpl implements AuthService {
     if (request.getUserPassword() != null) {
       user.setPassword(passwordEncoder.encode(request.getUserPassword()));
     }
-    if (request.getNotifyStatus() != null) {
-      user.setNotification(request.getNotifyStatus());
-    }
 
     return UpdateUserResponse.builder()
         .userId(user.getUserId())
         .userName(user.getName())
-        .notifyStatus(user.isNotification())
         .updatedAt(ZonedDateTime.now())
         .build();
   }

--- a/meerkatai/src/main/java/com/capstone/meerkatai/user/service/AuthServiceImpl.java
+++ b/meerkatai/src/main/java/com/capstone/meerkatai/user/service/AuthServiceImpl.java
@@ -147,9 +147,21 @@ public class AuthServiceImpl implements AuthService {
     User user = userRepository.findByEmail(request.getUserEmail())
         .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
 
+    // 기존 비밀번호 확인
+    if (!passwordEncoder.matches(request.getUserPassword(), user.getPassword())) {
+      throw new BadCredentialsException("현재 비밀번호가 일치하지 않습니다.");
+    }
+    
+    // 새 비밀번호가 현재 비밀번호와 동일한지 확인
+    if (passwordEncoder.matches(request.getNewPassword(), user.getPassword())) {
+      throw new IllegalArgumentException("새 비밀번호는 현재 비밀번호와 달라야 합니다.");
+    }
+
     // 새 비밀번호 암호화 및 저장
     String encodedPassword = passwordEncoder.encode(request.getNewPassword());
     user.setPassword(encodedPassword);
+    
+    log.info("사용자 {} 비밀번호 변경 완료", user.getEmail());
   }
 
   /**


### PR DESCRIPTION
## 기능 추가:
feat: 로그인시 notify_status 반환구현

feat: 비밀번호 초기화시 기존비밀번호 검증로직

fix: 회원정보수정에서 notify_status제거:

feat: 인증 오류메시지 구현

## 변경 사항:
## 버그 수정:
## 개선 사항:
## 테스트 사항:

feat: 로그인시 notify_status 반환구현
<img width="609" alt="image" src="https://github.com/user-attachments/assets/cf46ab65-a543-47ce-884b-123426527a3c" />

feat: 비밀번호 초기화시 기존비밀번호 검증로직
<img width="607" alt="image" src="https://github.com/user-attachments/assets/3d7e6b20-382d-4d04-b016-9d5024097593" />

fix: 회원정보수정에서 notify_status제거:
<img width="613" alt="image" src="https://github.com/user-attachments/assets/c97eab27-ee6c-4e2c-b7ea-920f6d962b3c" />

feat: 인증 오류메시지 구현
<img width="589" alt="image" src="https://github.com/user-attachments/assets/9b0df430-c980-4cd6-97d4-4b0c24f01bc0" />


## 참고 사항:
